### PR TITLE
Removed failing iOS env from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_install:
 env:  
   matrix: 
     - UDID="E5486005-1831-4DBE-B151-B54F00F798C9", IOS_DEVICE="iPhone XS Max (12.0)"  
-    - UDID="BF136388-A0C8-4E11-8FAD-1E03E3DEA881", IOS_DEVICE="iPhone 6 (8.1)"
 
 script:
   - set -o pipefail


### PR DESCRIPTION
<!--- Thank you for helping contribute to SwiftVideoBackground! 🎉 --->

<!--- Please take a second to fill in the below information, to help the maintainers ensure that this PR is merged as soon as possible. --->

<!--- Also, if you are currently still working on the PR, and not ready for a maintainer to review, please add [WIP] to your PR title. --->

## What does this PR do?

<!--- Answer below --->
Fixes travis builds by removing a failing iOS env

## What issues (if any) are related to this PR? Or why was this change introduced?

<!--- Answer below --->
#74 

## Checklist

 - [ ] Does this contain code changes?
 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?