### PR TITLE
Fixes framework target error

### DIFF
--- a/SwiftVideoBackground.xcodeproj/project.pbxproj
+++ b/SwiftVideoBackground.xcodeproj/project.pbxproj
@@ -375,7 +375,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.wilsonding.SwiftVideoBackground;
 				PRODUCT_NAME = SwiftVideoBackground;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -402,7 +402,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.wilsonding.SwiftVideoBackground;
 				PRODUCT_NAME = SwiftVideoBackground;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";


### PR DESCRIPTION
Fixes framework target error, this target it's not set to swift5,
causing an error with carthage

<!--- Thank you for helping contribute to SwiftVideoBackground! 🎉 --->

<!--- Please take a second to fill in the below information, to help the maintainers ensure that this PR is merged as soon as possible. --->

<!--- Also, if you are currently still working on the PR, and not ready for a maintainer to review, please add [WIP] to your PR title. --->

## What does this PR do?

<!--- Answer below --->
Fixes framework target error, this target it's not set to swift5,
causing an error with carthage


## What issues (if any) are related to this PR? Or why was this change introduced?

<!--- Answer below --->
```
$ carthage update --platform iOS
*** Building scheme "SwiftVideoBackground-iOS" in SwiftVideoBackground.xcodeproj
Build Failed
	Task failed with exit code 65:
	/usr/bin/xcrun xcodebuild -project /Users/nebiros/ios/studio-ios/Carthage/Checkouts/SwiftVideoBackground/SwiftVideoBackground.xcodeproj -scheme SwiftVideoBackground-iOS -configuration Release -derivedDataPath /Users/nebiros/Library/Caches/org.carthage.CarthageKit/DerivedData/10.3_10G8/SwiftVideoBackground/3.4.0 -sdk iphoneos ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES archive -archivePath /var/folders/bg/q5lvd51j5qz4jhrrfbfs3ycr0000gn/T/SwiftVideoBackground SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO STRIP_INSTALLED_PRODUCT=NO (launched in /Users/nebiros/ios/studio-ios/Carthage/Checkouts/SwiftVideoBackground)
```

## Checklist

 - [ ] Does this contain code changes?
 - [ ] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?